### PR TITLE
Change folder name in quick start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ curl -sSL https://install.python-poetry.org | python3 -
 ### 2. Clone and Setup Project
 ```bash
 git clone https://github.com/drmingler/docling-api.git
-cd document-converter
+cd docling-api
 poetry install
 ```
 
@@ -134,7 +134,7 @@ curl -X POST "http://localhost:8080/documents/convert" \
 1. Clone the repository:
 ```bash
 git clone https://github.com/drmingler/docling-api.git
-cd document-converter
+cd docling-api
 ```
 
 2. Create a `.env` file:


### PR DESCRIPTION
Looks like the name of the project has changed over time. I tested the quick start instructions for docker, these changes appear correct for that.